### PR TITLE
Add entry for Clojure and ClojureScript

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -27,6 +27,12 @@ trim_trailing_whitespace = true
 indent_size = 4
 indent_style = space
 
+# Clojure: https://clojure.org/
+# https://guide.clojure.style/
+[*.{clj,cljs}]
+indent_size = 2
+indent_style = space
+
 # CSS
 # https://google.github.io/styleguide/htmlcssguide.xml#General_Formatting_Rules
 # http://cssguidelin.es/#syntax-and-formatting


### PR DESCRIPTION
Cool project! Here's an entry for Clojure.

The citation for guide.clojure.style also matches the style used by the Clojure project itself.

See
- https://github.com/clojure/clojure
- https://github.com/clojure/clojurescript